### PR TITLE
Update jssorslider-rails.gemspec

### DIFF
--- a/jssorslider-rails.gemspec
+++ b/jssorslider-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", "~> 3.1"
+  spec.add_dependency "railties", "=> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Not working for railties version > 4.0.
